### PR TITLE
검색 탭의 영역을 나누고, 검색창 레이아웃을 구현했습니다.

### DIFF
--- a/Eve_Student_IKEA/Base.lproj/Main.storyboard
+++ b/Eve_Student_IKEA/Base.lproj/Main.storyboard
@@ -112,19 +112,106 @@
             <objects>
                 <viewController id="7Uh-ld-xiX" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Our-f8-miA">
-                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="1800"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mux-vr-VAl">
+                                <rect key="frame" x="0.0" y="47" width="390" height="1753"/>
+                                <subviews>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jcs-RR-p4C">
+                                        <rect key="frame" x="0.0" y="0.0" width="390" height="1400"/>
+                                        <subviews>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="n3n-zl-VNl">
+                                                <rect key="frame" x="0.0" y="0.0" width="390" height="1400"/>
+                                                <subviews>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="arO-MQ-HoF">
+                                                        <rect key="frame" x="0.0" y="0.0" width="390" height="200"/>
+                                                        <color key="backgroundColor" systemColor="systemIndigoColor"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="200" id="jk5-Ay-JNV"/>
+                                                        </constraints>
+                                                    </view>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="D9r-xi-jVb">
+                                                        <rect key="frame" x="0.0" y="200" width="390" height="200"/>
+                                                        <color key="backgroundColor" systemColor="systemMintColor"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="200" id="JmY-4f-Lk0"/>
+                                                        </constraints>
+                                                    </view>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3RS-CD-ekC">
+                                                        <rect key="frame" x="0.0" y="400" width="390" height="200"/>
+                                                        <color key="backgroundColor" systemColor="systemOrangeColor"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="200" id="MSC-Tv-Yk7"/>
+                                                        </constraints>
+                                                    </view>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="RWe-lG-rnC">
+                                                        <rect key="frame" x="0.0" y="600" width="390" height="200"/>
+                                                        <color key="backgroundColor" systemColor="systemPinkColor"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="200" id="lVS-67-hSO"/>
+                                                        </constraints>
+                                                    </view>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Pzq-Yq-YaQ">
+                                                        <rect key="frame" x="0.0" y="800" width="390" height="200"/>
+                                                        <color key="backgroundColor" systemColor="systemPurpleColor"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="200" id="qYu-pV-QZU"/>
+                                                        </constraints>
+                                                    </view>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Rlz-nC-0vw">
+                                                        <rect key="frame" x="0.0" y="1000" width="390" height="200"/>
+                                                        <color key="backgroundColor" systemColor="systemRedColor"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="200" id="CYK-tY-LIs"/>
+                                                        </constraints>
+                                                    </view>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Wl3-Xo-agE">
+                                                        <rect key="frame" x="0.0" y="1200" width="390" height="200"/>
+                                                        <color key="backgroundColor" systemColor="systemYellowColor"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="200" id="v3f-Xj-WpE"/>
+                                                        </constraints>
+                                                    </view>
+                                                </subviews>
+                                            </stackView>
+                                        </subviews>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstItem="n3n-zl-VNl" firstAttribute="leading" secondItem="jcs-RR-p4C" secondAttribute="leading" id="EUh-H4-l3a"/>
+                                            <constraint firstAttribute="trailing" secondItem="n3n-zl-VNl" secondAttribute="trailing" id="GE6-Ze-fwO"/>
+                                            <constraint firstAttribute="bottom" secondItem="n3n-zl-VNl" secondAttribute="bottom" id="VTQ-OY-Kib"/>
+                                            <constraint firstItem="n3n-zl-VNl" firstAttribute="top" secondItem="jcs-RR-p4C" secondAttribute="top" id="izn-6o-HhN"/>
+                                        </constraints>
+                                    </view>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstAttribute="bottom" secondItem="jcs-RR-p4C" secondAttribute="bottom" id="621-1M-aus"/>
+                                    <constraint firstAttribute="trailing" secondItem="jcs-RR-p4C" secondAttribute="trailing" id="Bpz-aN-kZc"/>
+                                    <constraint firstItem="jcs-RR-p4C" firstAttribute="top" secondItem="mux-vr-VAl" secondAttribute="top" id="L9P-h5-vZR"/>
+                                    <constraint firstItem="jcs-RR-p4C" firstAttribute="width" secondItem="mux-vr-VAl" secondAttribute="width" id="LZt-Y3-8NU"/>
+                                    <constraint firstItem="jcs-RR-p4C" firstAttribute="leading" secondItem="mux-vr-VAl" secondAttribute="leading" id="Rhr-ws-iHW"/>
+                                </constraints>
+                            </scrollView>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="eaS-uL-uFL"/>
-                        <color key="backgroundColor" systemColor="systemPinkColor"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="mux-vr-VAl" firstAttribute="top" secondItem="eaS-uL-uFL" secondAttribute="top" id="1ty-l9-shr"/>
+                            <constraint firstItem="mux-vr-VAl" firstAttribute="leading" secondItem="eaS-uL-uFL" secondAttribute="leading" id="Pkd-7M-l7d"/>
+                            <constraint firstItem="mux-vr-VAl" firstAttribute="trailing" secondItem="eaS-uL-uFL" secondAttribute="trailing" id="eJl-Np-Cu6"/>
+                            <constraint firstAttribute="bottom" secondItem="mux-vr-VAl" secondAttribute="bottom" id="wTD-zQ-QR2"/>
+                        </constraints>
                     </view>
                     <tabBarItem key="tabBarItem" title="" id="MEo-NW-0gH">
                         <imageReference key="image" image="magnifyingglass" catalog="system" symbolScale="medium"/>
                     </tabBarItem>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
+                    <size key="freeformSize" width="390" height="1800"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="3Pc-LL-2As" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-605" y="540"/>
+            <point key="canvasLocation" x="-591" y="950"/>
         </scene>
     </scenes>
     <resources>
@@ -133,6 +220,9 @@
         <image name="house" catalog="system" width="128" height="104"/>
         <image name="magnifyingglass" catalog="system" width="128" height="117"/>
         <image name="person" catalog="system" width="128" height="121"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
         <systemColor name="systemIndigoColor">
             <color red="0.34509803921568627" green="0.33725490196078434" blue="0.83921568627450982" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
@@ -147,6 +237,12 @@
         </systemColor>
         <systemColor name="systemPurpleColor">
             <color red="0.68627450980392157" green="0.32156862745098042" blue="0.87058823529411766" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemRedColor">
+            <color red="1" green="0.23137254901960785" blue="0.18823529411764706" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemYellowColor">
+            <color red="1" green="0.80000000000000004" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/Eve_Student_IKEA/Base.lproj/Main.storyboard
+++ b/Eve_Student_IKEA/Base.lproj/Main.storyboard
@@ -35,8 +35,8 @@
                     <tabBar key="tabBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translucent="NO" id="ZVN-vV-5vX">
                         <rect key="frame" x="0.0" y="0.0" width="390" height="49"/>
                         <autoresizingMask key="autoresizingMask"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <color key="selectedImageTintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="selectedImageTintColor" systemColor="labelColor"/>
                     </tabBar>
                     <connections>
                         <segue destination="IvT-LR-bPI" kind="relationship" relationship="viewControllers" id="tla-iV-fXL"/>
@@ -195,7 +195,7 @@
                             </scrollView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="eaS-uL-uFL"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="mux-vr-VAl" firstAttribute="top" secondItem="eaS-uL-uFL" secondAttribute="top" id="1ty-l9-shr"/>
                             <constraint firstItem="mux-vr-VAl" firstAttribute="leading" secondItem="eaS-uL-uFL" secondAttribute="leading" id="Pkd-7M-l7d"/>
@@ -220,6 +220,9 @@
         <image name="house" catalog="system" width="128" height="104"/>
         <image name="magnifyingglass" catalog="system" width="128" height="117"/>
         <image name="person" catalog="system" width="128" height="121"/>
+        <systemColor name="labelColor">
+            <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/Eve_Student_IKEA/Base.lproj/Main.storyboard
+++ b/Eve_Student_IKEA/Base.lproj/Main.storyboard
@@ -119,23 +119,23 @@
                                 <rect key="frame" x="0.0" y="47" width="390" height="1753"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jcs-RR-p4C">
-                                        <rect key="frame" x="0.0" y="0.0" width="390" height="1370"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="390" height="1380"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="n3n-zl-VNl">
-                                                <rect key="frame" x="0.0" y="0.0" width="390" height="1370"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="390" height="1380"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="arO-MQ-HoF">
-                                                        <rect key="frame" x="0.0" y="0.0" width="390" height="170"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="390" height="180"/>
                                                         <subviews>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6HL-mz-qSm">
-                                                                <rect key="frame" x="20" y="70" width="350" height="50"/>
+                                                                <rect key="frame" x="20" y="80" width="350" height="50"/>
                                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="50" id="7aa-J6-xAR"/>
                                                                 </constraints>
                                                             </view>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="검색" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UyS-hX-UrD">
-                                                                <rect key="frame" x="20" y="20" width="350" height="30"/>
+                                                                <rect key="frame" x="20" y="30" width="350" height="30"/>
                                                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="25"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -148,47 +148,47 @@
                                                             <constraint firstItem="6HL-mz-qSm" firstAttribute="top" secondItem="UyS-hX-UrD" secondAttribute="bottom" constant="20" id="Gsk-LN-9Mv"/>
                                                             <constraint firstItem="UyS-hX-UrD" firstAttribute="leading" secondItem="arO-MQ-HoF" secondAttribute="leading" constant="20" id="Kri-51-uuY"/>
                                                             <constraint firstAttribute="trailing" secondItem="UyS-hX-UrD" secondAttribute="trailing" constant="20" id="UEi-GC-LEn"/>
-                                                            <constraint firstItem="UyS-hX-UrD" firstAttribute="top" secondItem="arO-MQ-HoF" secondAttribute="top" constant="20" id="akX-vc-oaW"/>
-                                                            <constraint firstAttribute="height" constant="170" id="jk5-Ay-JNV"/>
+                                                            <constraint firstItem="UyS-hX-UrD" firstAttribute="top" secondItem="arO-MQ-HoF" secondAttribute="top" constant="30" id="akX-vc-oaW"/>
+                                                            <constraint firstAttribute="height" constant="180" id="jk5-Ay-JNV"/>
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="D9r-xi-jVb">
-                                                        <rect key="frame" x="0.0" y="170" width="390" height="200"/>
+                                                        <rect key="frame" x="0.0" y="180" width="390" height="200"/>
                                                         <color key="backgroundColor" systemColor="systemMintColor"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="200" id="JmY-4f-Lk0"/>
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3RS-CD-ekC">
-                                                        <rect key="frame" x="0.0" y="370" width="390" height="200"/>
+                                                        <rect key="frame" x="0.0" y="380" width="390" height="200"/>
                                                         <color key="backgroundColor" systemColor="systemOrangeColor"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="200" id="MSC-Tv-Yk7"/>
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="RWe-lG-rnC">
-                                                        <rect key="frame" x="0.0" y="570" width="390" height="200"/>
+                                                        <rect key="frame" x="0.0" y="580" width="390" height="200"/>
                                                         <color key="backgroundColor" systemColor="systemPinkColor"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="200" id="lVS-67-hSO"/>
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Pzq-Yq-YaQ">
-                                                        <rect key="frame" x="0.0" y="770" width="390" height="200"/>
+                                                        <rect key="frame" x="0.0" y="780" width="390" height="200"/>
                                                         <color key="backgroundColor" systemColor="systemPurpleColor"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="200" id="qYu-pV-QZU"/>
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Rlz-nC-0vw">
-                                                        <rect key="frame" x="0.0" y="970" width="390" height="200"/>
+                                                        <rect key="frame" x="0.0" y="980" width="390" height="200"/>
                                                         <color key="backgroundColor" systemColor="systemRedColor"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="200" id="CYK-tY-LIs"/>
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Wl3-Xo-agE">
-                                                        <rect key="frame" x="0.0" y="1170" width="390" height="200"/>
+                                                        <rect key="frame" x="0.0" y="1180" width="390" height="200"/>
                                                         <color key="backgroundColor" systemColor="systemYellowColor"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="200" id="v3f-Xj-WpE"/>

--- a/Eve_Student_IKEA/Base.lproj/Main.storyboard
+++ b/Eve_Student_IKEA/Base.lproj/Main.storyboard
@@ -119,55 +119,76 @@
                                 <rect key="frame" x="0.0" y="47" width="390" height="1753"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jcs-RR-p4C">
-                                        <rect key="frame" x="0.0" y="0.0" width="390" height="1400"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="390" height="1370"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="n3n-zl-VNl">
-                                                <rect key="frame" x="0.0" y="0.0" width="390" height="1400"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="390" height="1370"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="arO-MQ-HoF">
-                                                        <rect key="frame" x="0.0" y="0.0" width="390" height="200"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="390" height="170"/>
+                                                        <subviews>
+                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6HL-mz-qSm">
+                                                                <rect key="frame" x="20" y="70" width="350" height="50"/>
+                                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" constant="50" id="7aa-J6-xAR"/>
+                                                                </constraints>
+                                                            </view>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="검색" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UyS-hX-UrD">
+                                                                <rect key="frame" x="20" y="20" width="350" height="30"/>
+                                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="25"/>
+                                                                <nil key="textColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                        </subviews>
                                                         <color key="backgroundColor" systemColor="systemIndigoColor"/>
                                                         <constraints>
-                                                            <constraint firstAttribute="height" constant="200" id="jk5-Ay-JNV"/>
+                                                            <constraint firstItem="6HL-mz-qSm" firstAttribute="leading" secondItem="arO-MQ-HoF" secondAttribute="leading" constant="20" id="7a0-Kt-tNg"/>
+                                                            <constraint firstAttribute="trailing" secondItem="6HL-mz-qSm" secondAttribute="trailing" constant="20" id="AYU-kG-WmL"/>
+                                                            <constraint firstItem="6HL-mz-qSm" firstAttribute="top" secondItem="UyS-hX-UrD" secondAttribute="bottom" constant="20" id="Gsk-LN-9Mv"/>
+                                                            <constraint firstItem="UyS-hX-UrD" firstAttribute="leading" secondItem="arO-MQ-HoF" secondAttribute="leading" constant="20" id="Kri-51-uuY"/>
+                                                            <constraint firstAttribute="trailing" secondItem="UyS-hX-UrD" secondAttribute="trailing" constant="20" id="UEi-GC-LEn"/>
+                                                            <constraint firstItem="UyS-hX-UrD" firstAttribute="top" secondItem="arO-MQ-HoF" secondAttribute="top" constant="20" id="akX-vc-oaW"/>
+                                                            <constraint firstAttribute="height" constant="170" id="jk5-Ay-JNV"/>
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="D9r-xi-jVb">
-                                                        <rect key="frame" x="0.0" y="200" width="390" height="200"/>
+                                                        <rect key="frame" x="0.0" y="170" width="390" height="200"/>
                                                         <color key="backgroundColor" systemColor="systemMintColor"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="200" id="JmY-4f-Lk0"/>
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3RS-CD-ekC">
-                                                        <rect key="frame" x="0.0" y="400" width="390" height="200"/>
+                                                        <rect key="frame" x="0.0" y="370" width="390" height="200"/>
                                                         <color key="backgroundColor" systemColor="systemOrangeColor"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="200" id="MSC-Tv-Yk7"/>
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="RWe-lG-rnC">
-                                                        <rect key="frame" x="0.0" y="600" width="390" height="200"/>
+                                                        <rect key="frame" x="0.0" y="570" width="390" height="200"/>
                                                         <color key="backgroundColor" systemColor="systemPinkColor"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="200" id="lVS-67-hSO"/>
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Pzq-Yq-YaQ">
-                                                        <rect key="frame" x="0.0" y="800" width="390" height="200"/>
+                                                        <rect key="frame" x="0.0" y="770" width="390" height="200"/>
                                                         <color key="backgroundColor" systemColor="systemPurpleColor"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="200" id="qYu-pV-QZU"/>
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Rlz-nC-0vw">
-                                                        <rect key="frame" x="0.0" y="1000" width="390" height="200"/>
+                                                        <rect key="frame" x="0.0" y="970" width="390" height="200"/>
                                                         <color key="backgroundColor" systemColor="systemRedColor"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="200" id="CYK-tY-LIs"/>
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Wl3-Xo-agE">
-                                                        <rect key="frame" x="0.0" y="1200" width="390" height="200"/>
+                                                        <rect key="frame" x="0.0" y="1170" width="390" height="200"/>
                                                         <color key="backgroundColor" systemColor="systemYellowColor"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="200" id="v3f-Xj-WpE"/>
@@ -211,7 +232,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="3Pc-LL-2As" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-591" y="950"/>
+            <point key="canvasLocation" x="-592.30769230769226" y="949.76303317535542"/>
         </scene>
     </scenes>
     <resources>


### PR DESCRIPTION
## 👀 관련 이슈
- close #3 
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->

## 👀 배경
IKEA 앱 검색탭의 영역을 나누고, 검색창 레이아웃을 구현합니다.
<!--  -->

## 👀 작업 내용
- 검색탭을 검색창/최근 본 제품/제품 찾아보기/캠페인/인기제품/로그인/정보의 7가지 영역으로 나눴습니다.
- `Scroll View`를 활용해 Scroll 되는 검색탭 형태를 구현하고, 그 위에 `Stack View`를 활용해 7개의 `UIView`를 올렸습니다.
- 첫번쨰 `UIView` 위에 검색 `Label`과 검색창이 될 `UIView`를 올렸습니다.
<!-- 구현/변경한 내용을 적어주세요 -->

## 👀 PR Point
- StoryBoard 형태라서 제 브랜치로 checkout한 다음에 리뷰해주시면 감사하겠습니다.
- 검색창을 구현하는 방식이 `Stack View`를 적절히 활용한 방식이 맞는지 모르겠습니다. `Stack View` 위에 `UIView`를 올리고, 그 위에 다시 `Label`과 검색창이 될 `UIView`를 올리면 `Stack View`의 height는 제가 수동으로 조절해야 하기 때문입니다. 더 좋은 방식이 있으면 추천해 주시면 감사하겠습니다.
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

## 👀 참고 사항
<img src="https://user-images.githubusercontent.com/49133245/194576876-bdce7061-78d6-48d5-9196-d43677cbd586.png" alt="drawing" width="300"/>
<!-- 참고할 사항(스크린샷, 실행 시 유의할 점, 참고 링크)이 있다면 적어주세요. -->
